### PR TITLE
Corrigido o bug do css 'transform-origin'.

### DIFF
--- a/loader-svg/octocat-loader.svg
+++ b/loader-svg/octocat-loader.svg
@@ -13,7 +13,7 @@
         }
 
         #arm {
-            transform-origin: bottom right;
+            transform-origin: 50% 75%;
             animation: swing-arm 1s alternate infinite;
         }
 


### PR DESCRIPTION
Ola Willian, 
Estou fazendo o seu curso de SVG na Udemy (que é incrível diga-se de passagem). E me deparei com um bug que foi introduzido nas atualizações mais recentes dos navegadores atuais. 
Esse bug faz com que o ao aplicar a transformação de origem em um elemento filho do SVG, seja relativa a tag SVG e não ao elemento que recebeu. Isso fez com que a animação seja renderizada da seguinte maneira:
![loader-1](https://user-images.githubusercontent.com/22581882/43362112-3e02dab4-92b8-11e8-8e7f-6a2f956380d5.gif)
(a origem da rotação é do canto inferior direito do tag SVG e não do elemento de id arm)

Para corrigir isso basta alterar a transformação de origem para 50% 75%. Que é mais ou menos a posição da base do rabo do octocat relativa a viewbox do SVG.

![liader-2](https://user-images.githubusercontent.com/22581882/43362146-0b6502ac-92b9-11e8-9ea3-1826e4e54bf3.gif)

(testado no chrome 67 e no firefox 57)
